### PR TITLE
Removed print at launch

### DIFF
--- a/food-shopper/FoodShopper.cs
+++ b/food-shopper/FoodShopper.cs
@@ -408,8 +408,6 @@ namespace FoodShopper
 
         static void Main(string[] args)
         {
-            // Do not remove this print out - helps with the TizenFX stub sync issue
-            Console.WriteLine("Running Example...");
             FoodShopperDemo foodShopperDemo = new FoodShopperDemo();
             foodShopperDemo.Run(args);
         }

--- a/hello-world/HelloWorld.cs
+++ b/hello-world/HelloWorld.cs
@@ -57,8 +57,6 @@ class HelloWorldExample : NUIApplication
     [STAThread] // Forces app to use one thread to access NUI
     static void Main(string[] args)
     {
-        // Do not remove this print out - helps with the TizenFX stub sync issue
-        Console.WriteLine("Running Example...");
         HelloWorldExample example = new HelloWorldExample();
         example.Run(args);
     }

--- a/layout-demo/LayoutDemo.cs
+++ b/layout-demo/LayoutDemo.cs
@@ -208,8 +208,6 @@ namespace LayoutDemo
 
         static void Main(string[] args)
         {
-            // Do not remove this print out - helps with the TizenFX stub sync issue
-            Console.WriteLine("Running Example...");
             LayoutingExample example = new LayoutingExample();
             example.Run(args);
         }

--- a/multiple-window/MultipleWindow.cs
+++ b/multiple-window/MultipleWindow.cs
@@ -489,8 +489,6 @@ class MultipleWindowExample : NUIApplication
     [STAThread] // Forces app to use one thread to access NUI
     static void Main(string[] args)
     {
-        // Do not remove this print out - helps with the TizenFX stub sync issue
-        Console.WriteLine("Running Example.......");
         MultipleWindowExample example = new MultipleWindowExample(new Size2D(1290, 200), new Position2D(0, 0));
         example.Run(args);
     }

--- a/silk-demo/SilkDemo.cs
+++ b/silk-demo/SilkDemo.cs
@@ -596,8 +596,6 @@ namespace Silk
 
         static void Main(string[] args)
         {
-            // Do not remove this print out - helps with the TizenFX stub sync issue
-            Console.WriteLine("Running Example...");
             Demo silkDemo = new Demo();
             silkDemo.Run(args);
         }

--- a/simple-layout/SimpleLayout.cs
+++ b/simple-layout/SimpleLayout.cs
@@ -77,8 +77,6 @@ namespace SimpleLayout
 
         static void Main(string[] args)
         {
-            // Do not remove this print out - helps with the TizenFX stub sync issue
-            Console.WriteLine("Running Example...");
             SimpleLayout simpleLayout = new SimpleLayout();
             simpleLayout.Run(args);
         }

--- a/simple-text/simple-text.cs
+++ b/simple-text/simple-text.cs
@@ -334,8 +334,6 @@ namespace HelloWorldTest
         [STAThread]
         static void Main(string[] args)
         {
-            // Do not remove this print out - helps with the TizenFX stub sync issue
-            Console.WriteLine("Running Example...");
             Example example = new Example();
             example.Run(args);
         }


### PR DESCRIPTION
- This was in place to hide the launching bug
- It's not required anymore as the bug has been fixed in
  dali-csharp-binder

Change-Id: Ia971993bedebb80e5254892d4fbb39d89e1f0819