### PR TITLE
Change Tizen.NUI.Components.ScrollableBase's event names

### DIFF
--- a/layout-demo/ScrollingListExample.cs
+++ b/layout-demo/ScrollingListExample.cs
@@ -110,8 +110,8 @@ namespace LayoutDemo
             };
 
             scrollable.Add(listViewContainer);
-            scrollable.ScrollAnimationEndEvent += OnScrollEnded;
-            scrollable.ScrollDragStartEvent += OnScrollStarted;
+            scrollable.ScrollAnimationEnded += OnScrollEnded;
+            scrollable.ScrollDragStarted += OnScrollStarted;
 
             root.Add(scrollable);
         }

--- a/wearable-samples/Pagination/CircularPagination/CircularPaginationExample.cs
+++ b/wearable-samples/Pagination/CircularPagination/CircularPaginationExample.cs
@@ -98,7 +98,7 @@ public class CircularPaginationExample : NUIApplication
         window.WheelEvent += Pagination_WheelEvent;
 
         // Screen Touch Event
-        scrollable.ScrollAnimationEndEvent  += Scroll_AnimationEnd;
+        scrollable.ScrollAnimationEnded  += Scroll_AnimationEnded;
     }
 
     private void Pagination_WheelEvent(object source, Window.WheelEventArgs e)
@@ -127,7 +127,7 @@ public class CircularPaginationExample : NUIApplication
     }
 
     // There are two ways to set the current selected index using ScrollableBase event.
-    void Scroll_AnimationEnd(object source, ScrollableBase.ScrollEventArgs e)
+    void Scroll_AnimationEnded(object source, ScrollableBase.ScrollEventArgs e)
     {
         ///////////////////// 1. Using the parameter of the event /////////////////////
         // e.Position.X means the top-left position of ScrollableBase and Container.

--- a/wearable-samples/Pagination/LinearPagination/LinearPaginationExample.cs
+++ b/wearable-samples/Pagination/LinearPagination/LinearPaginationExample.cs
@@ -99,7 +99,7 @@ public class LinearPaginationExample : NUIApplication
         window.WheelEvent += Pagination_WheelEvent;
 
         // Screen Touch Event
-        scrollable.ScrollAnimationEndEvent  += Scroll_AnimationEnd;
+        scrollable.ScrollAnimationEnded  += Scroll_AnimationEnded;
     }
 
     private void Pagination_WheelEvent(object source, Window.WheelEventArgs e)
@@ -128,7 +128,7 @@ public class LinearPaginationExample : NUIApplication
     }
 
     // There are two ways to set the current selected index using ScrollableBase event.
-    void Scroll_AnimationEnd(object source, ScrollableBase.ScrollEventArgs e)
+    void Scroll_AnimationEnded(object source, ScrollableBase.ScrollEventArgs e)
     {
         ///////////////////// 1. Using the parameter of the event /////////////////////
         // e.Position.X means the top-left position of ScrollableBase and Container.

--- a/wearable-samples/ReferenceApplication/WHome/NUIWHMain/SampleCreator/SampleCreator.cs
+++ b/wearable-samples/ReferenceApplication/WHome/NUIWHMain/SampleCreator/SampleCreator.cs
@@ -298,11 +298,11 @@ namespace NUIWHMain
             view.Add(pagination);
             
             // Screen Touch Event
-            scrollable.ScrollAnimationEndEvent += Scroll_AnimationEnd;
+            scrollable.ScrollAnimationEnded += Scroll_AnimationEnded;
             return view;
         }
 
-        void Scroll_AnimationEnd(object source, ScrollableBase.ScrollEventArgs e)
+        void Scroll_AnimationEnded(object source, ScrollableBase.ScrollEventArgs e)
         {
             int index = scrollable.CurrentPage;
 


### PR DESCRIPTION
The Tizen.NUI.Components.ScrollableBase's event names are changed as
follows in TizenFX.
- ScrollEvent -> Scrolling
- ScrollDragStartEvent -> ScrollDragStarted
- ScrollDragEndEvent -> ScrollDragEnded
- ScrollAnimationStartEvent -> ScrollAnimationStarted
- ScrollAnimationEndEvent -> ScrollAnimationEnded