### PR TITLE
[FoodShopper] replace SetColumns with Columns

### DIFF
--- a/food-shopper/PersistantBar.cs
+++ b/food-shopper/PersistantBar.cs
@@ -55,7 +55,7 @@ namespace FoodShopper
             settingsCluster = new View();
             settingsCluster.Name = "settingsCluster";
             settingsClusterLayout = new GridLayout();
-            settingsClusterLayout.SetColumns( 2 );
+            settingsClusterLayout.Columns = 2;
             //settingsClusterLayout.LayoutAnimate = true;
             UnFocused();
             Add(settingsCluster);


### PR DESCRIPTION
`GridLayout.SetColumns` is removed because it is a duplicate of
`GridLayout.Columns`.

Also, this will fix build error.